### PR TITLE
meson: Fix usage of deprecated source_root and build_root in tests setup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project(
 		'strip=true'
 	],
 	version: '1.1.1',
-	meson_version: '>=0.53'
+	meson_version: '>=0.56'
 )
 
 cc = meson.get_compiler('c')

--- a/test/crunch++/meson.build
+++ b/test/crunch++/meson.build
@@ -2,7 +2,7 @@ libCrunchppTestsNorm = ['testArgsParser', 'testCrunch++', 'testBad', 'testRegist
 libCrunchppTestsExcept = ['testTester']
 libCrunchppTests = libCrunchppTestsNorm + libCrunchppTestsExcept
 
-libCrunchppPath = join_paths([meson.build_root(), libCrunchpp.outdir()])
+libCrunchppPath = join_paths([meson.project_build_root(), libCrunchpp.outdir()])
 
 if not isWindows
 	testSrcs = [

--- a/test/crunch/meson.build
+++ b/test/crunch/meson.build
@@ -3,7 +3,7 @@ if not c11Threading
 	libCrunchTests += 'testThreadShim'
 endif
 
-libCrunchPath = join_paths([meson.build_root(), libCrunch.outdir()])
+libCrunchPath = join_paths([meson.project_build_root(), libCrunch.outdir()])
 
 foreach test : libCrunchTests
 	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + crunchSrcDir, '-L' + libCrunchPath]

--- a/test/ranlux/meson.build
+++ b/test/ranlux/meson.build
@@ -8,7 +8,7 @@ ranlux = static_library(
 )
 
 ranluxTests = ['testRanlux32', 'testRanlux64']
-libCrunchppPath = join_paths([meson.build_root(), libCrunchpp.outdir()])
+libCrunchppPath = join_paths([meson.project_build_root(), libCrunchpp.outdir()])
 ranluxSrcDir = meson.current_source_dir()
 
 objectMap = {
@@ -19,7 +19,7 @@ objectMap = {
 foreach test : ranluxTests
 	map = objectMap.get(test)
 	testObjs = [ranlux.extract_objects(map['test'] + ['helpers.cxx', 'ranlux64.cxx'])]
-	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + meson.source_root(), '-L' + libCrunchppPath]
+	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + meson.project_source_root(), '-L' + libCrunchppPath]
 	if isWindows and coverage
 		command = [coverageTarget, coverageRunner] + coverageArgs + [
 			'cobertura:crunchMake-@0@-coverage.xml'.format(test), '--'


### PR DESCRIPTION
:wave:

This PR is to fix some deprecations I noticed during testing.