### PR TITLE
ci: Fix MSVC 2019 compatibility by skipping testArgsParser inside Meson

### DIFF
--- a/crunchMake/meson.build
+++ b/crunchMake/meson.build
@@ -1,5 +1,5 @@
 crunchMakeSrc = ['crunchMake.cpp']
-if target_machine.system() == 'windows' and cxx.get_id() == 'msvc'
+if isWindows and isMSVC
 	crunchMakeSrc += ['compilerWindows.cxx']
 else
 	crunchMakeSrc += ['compilerUnixlike.cxx']

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ optimization = get_option('optimization')
 prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
 isWindows = target_machine.system() == 'windows'
+isMSVC = cxx.get_id() == 'msvc'
 dl = cxx.find_library('dl', required: not isWindows)
 libm = cxx.find_library('m', required: not isWindows)
 c11Threading = cc.get_define('__STD_NO_THREADS__') == '' and cc.check_header('threads.h')
@@ -96,7 +97,7 @@ else
 	)
 endif
 
-if cxx.get_id() == 'msvc'
+if isMSVC
 	add_project_arguments(
 		'-wd4996',
 		'-wd4800',

--- a/test/crunch++/meson.build
+++ b/test/crunch++/meson.build
@@ -1,6 +1,14 @@
-libCrunchppTestsNorm = ['testArgsParser', 'testCrunch++', 'testBad', 'testRegistration', 'testLogger']
+libCrunchppTestsNorm = ['testCrunch++', 'testBad', 'testRegistration', 'testLogger']
 libCrunchppTestsExcept = ['testTester']
 libCrunchppTests = libCrunchppTestsNorm + libCrunchppTestsExcept
+
+if isMSVC or cxx.version().version_compare('< 19.30.30704')
+	# MSVC 2019 crashes on testArgsParser
+	# https://developercommunity.visualstudio.com/t/Crash-on-constexpr-creation-of-a-std::ar/1547919
+	warning('Skipping testArgsParser test as it crashes MSVC')
+else
+	libCrunchppTestsNorm += ['testArgsParser']
+endif
 
 libCrunchppPath = join_paths([meson.project_build_root(), libCrunchpp.outdir()])
 

--- a/test/crunchMake/meson.build
+++ b/test/crunchMake/meson.build
@@ -2,7 +2,7 @@ if cxx.get_id() == 'gcc'
 	crunchMakeWrapper = find_program('crunchMakeGCC.py')
 elif cxx.get_id() == 'clang'
 	crunchMakeWrapper = find_program('crunchMakeClang.py')
-elif cxx.get_id() == 'msvc'
+elif isMSVC
 	crunchMakeWrapper = find_program('crunchMakeMSVC.py')
 else
 	crunchMakeWrapper = disabler()


### PR DESCRIPTION
:wave:

Second PR of last night's CI upgrade branch.