### PR TITLE
ci: Fix compatibility with MSYS compilers on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,10 +39,11 @@ if cxx.get_id() == 'clang' and sanitizer.contains('undefined')
 	assert(not noUndefined, 'Cannot combine b_lundef=true and b_sanitize=undefined')
 endif
 
+# Enable code coverage of the runner binaries and shared libraries - see
+# https://docs.jade.fyi/gnu/gcc/gcc.html#index-coverage for more details
 if ['gcc', 'clang'].contains(cc.get_id()) and coverage and debug
 	add_project_arguments('--coverage', language: 'c')
 endif
-
 if ['gcc', 'clang'].contains(cxx.get_id()) and coverage and debug
 	add_project_arguments('--coverage', language: 'cpp')
 endif
@@ -78,8 +79,11 @@ if isWindows
 		)
 	endif
 
-	coverageRunner = find_program('OpenCppCoverage', required: false)
-	coverage = coverageRunner.found() and debug
+	if isMSVC
+		coverageRunner = find_program('OpenCppCoverage', required: false)
+		coverage = coverageRunner.found() and debug
+	endif
+
 	if coverage
 		coverageArgs = [
 			'--sources', '@0@\crunch*\*'.format(meson.current_source_dir()),

--- a/test/crunch++/meson.build
+++ b/test/crunch++/meson.build
@@ -30,7 +30,7 @@ endif
 
 foreach test : libCrunchppTests
 	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + crunchppSrcDir, '-L' + libCrunchppPath]
-	if isWindows and coverage
+	if isMSVC and coverage
 		command = [coverageTarget, coverageRunner] + coverageArgs + [
 			'cobertura:crunchMake-crunch++-@0@-coverage.xml'.format(test), '--'
 		] + command
@@ -57,7 +57,7 @@ foreach test : libCrunchppTests
 	)
 endforeach
 
-if not isWindows or not coverage
+if not isMSVC or not coverage
 test(
 	'crunch++',
 	crunchpp,

--- a/test/crunch/meson.build
+++ b/test/crunch/meson.build
@@ -7,7 +7,7 @@ libCrunchPath = join_paths([meson.project_build_root(), libCrunch.outdir()])
 
 foreach test : libCrunchTests
 	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + crunchSrcDir, '-L' + libCrunchPath]
-	if isWindows and coverage
+	if isMSVC and coverage
 		command = [coverageTarget, coverageRunner] + coverageArgs + [
 			'cobertura:crunchMake-crunch-@0@-coverage.xml'.format(test), '--'
 		] + command
@@ -31,7 +31,7 @@ foreach test : libCrunchTests
 	)
 endforeach
 
-if not isWindows or not coverage
+if not isMSVC or not coverage
 test(
 	'crunch',
 	crunch,

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,7 +40,7 @@ subdir('crunch')
 subdir('crunch++')
 subdir('crunchMake')
 
-if not isWindows or not coverage
+if not isMSVC or not coverage
 test(
 	'crunchMake-none',
 	crunchMake,

--- a/test/ranlux/meson.build
+++ b/test/ranlux/meson.build
@@ -20,7 +20,7 @@ foreach test : ranluxTests
 	map = objectMap.get(test)
 	testObjs = [ranlux.extract_objects(map['test'] + ['helpers.cxx', 'ranlux64.cxx'])]
 	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + meson.project_source_root(), '-L' + libCrunchppPath]
-	if isWindows and coverage
+	if isMSVC and coverage
 		command = [coverageTarget, coverageRunner] + coverageArgs + [
 			'cobertura:crunchMake-@0@-coverage.xml'.format(test), '--'
 		] + command
@@ -35,7 +35,7 @@ foreach test : ranluxTests
 		build_by_default: true
 	)
 
-	if not isWindows or not coverage
+	if not isMSVC or not coverage
 	test(
 		map['name'],
 		crunchpp,


### PR DESCRIPTION
👋 

This PR is to fix running Crunch inside MSYS. The bug is a textbook case of the Windows == MSVC assumption. Furthermore, not having OpenCppCoverage should only affect MSVC, as it provides support for only that particular ABI.