### PR TITLE
CI: upgrade jobs

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -4,23 +4,39 @@ on:
   push:
     branches-ignore:
       - 'coverityScan'
+  pull_request:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    name: '${{ matrix.os.id }} (${{ matrix.compiler }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os.id }}
     strategy:
       matrix:
+        os:
+          - { id: ubuntu-20.04, name: focal }
         compiler:
           - 'clang-9'
           - 'clang-10'
           - 'clang-11'
           - 'clang-12'
+          - 'clang-13'
+          - 'clang-14'
+          - 'clang-15'
           - 'gcc-7'
           - 'gcc-8'
           - 'gcc-9'
           - 'gcc-10'
           - 'gcc-11'
-        coverage: [false, true]
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -30,15 +46,6 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
-      - name: Coverage environment
-        env:
-          COVERAGE: ${{ matrix.coverage }}
-        run: |
-          echo "Coverage enabled for build? ${{ matrix.coverage }}"
-          echo -n "COVERAGE=" >> $GITHUB_ENV
-          ([ $COVERAGE == "true" ] && echo 1 || echo 0) >> $GITHUB_ENV
-          echo -n "BUILD_OPTS=" >> $GITHUB_ENV
-          ([ $COVERAGE == "true" ] && echo "--buildtype=debug" || echo "") >> $GITHUB_ENV
       - name: Setup GCC
         if: startsWith(matrix.compiler, 'gcc')
         shell: bash
@@ -49,7 +56,6 @@ jobs:
           sudo apt-get install $CC $CXX
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
-          [ $COVERAGE -ne 0 ] && echo "GCOV=${CC/#gcc/gcov}" >> $GITHUB_ENV || true
         env:
           CC: ${{ matrix.compiler }}
       - name: Setup Clang
@@ -59,46 +65,151 @@ jobs:
           wget https://apt.llvm.org/llvm-snapshot.gpg.key
           sudo apt-key add llvm-snapshot.gpg.key
           rm llvm-snapshot.gpg.key
-          sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal${CC/#clang/} main"
+          sudo apt-add-repository "deb https://apt.llvm.org/${{ matrix.os.name }}/ llvm-toolchain-${{ matrix.os.name }}${CC/#clang/} main"
           sudo apt-get update
           CXX=${CC/#clang/clang++}
           sudo apt-get install $CC $CXX
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
-          [ $COVERAGE -ne 0 ] && echo "GCOV=/usr/lib/${CC/#clang/llvm}/bin/llvm-cov gcov" >> $GITHUB_ENV || true
         env:
           CC: ${{ matrix.compiler }}
         working-directory: ${{ runner.temp }}
-      - name: Chekcout crunch
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           lfs: true
           submodules: true
       - name: Setup Meson + Ninja
         shell: bash
         run: |
-          wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
-          sudo pip3 install --upgrade pip setuptools wheel
-          pip3 install --user meson
-          unzip ninja-linux.zip -d ~/.local/bin
-          rm ninja-linux.zip
+          sudo python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install --user meson ninja
         working-directory: ${{ runner.temp }}
       - name: Version tools
         shell: bash
         run: |
           $CC --version
           $CXX --version
-          [ $COVERAGE -ne 0 ] && $GCOV --version || true
           meson --version
           ninja --version
       - name: Configure
-        run: meson build --prefix=$HOME/.local -Db_coverage=${{ matrix.coverage }} $BUILD_OPTS
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }}
       - name: Build
         run: ninja -C build
       - name: Test
         run: ninja -C build test
       - name: Install
         run: ninja -C build install
+
+  build-coverage-linux:
+    if: github.repository == 'dragonmux/crunch'
+    name: 'coverage ${{ matrix.os.id }} (${{ matrix.compiler }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os.id }}
+    strategy:
+      matrix:
+        os:
+          - { id: ubuntu-20.04, name: focal }
+        compiler:
+          - 'clang-9'
+          - 'clang-10'
+          - 'clang-11'
+          - 'clang-12'
+          - 'clang-13'
+          - 'clang-14'
+          - 'clang-15'
+          - 'gcc-7'
+          - 'gcc-8'
+          - 'gcc-9'
+          - 'gcc-10'
+          - 'gcc-11'
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Coverage environment
+        run: |
+          echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV
+      - name: Setup GCC
+        if: startsWith(matrix.compiler, 'gcc')
+        shell: bash
+        run: |
+          CXX=${CC/#gcc/g++}
+          sudo apt-add-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install $CC $CXX gcovr
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "GCOV=${CC/#gcc/gcov}" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.compiler }}
+      - name: Setup Clang
+        if: startsWith(matrix.compiler, 'clang')
+        shell: bash
+        run: |
+          wget https://apt.llvm.org/llvm-snapshot.gpg.key
+          sudo apt-key add llvm-snapshot.gpg.key
+          rm llvm-snapshot.gpg.key
+          sudo apt-add-repository "deb https://apt.llvm.org/${{ matrix.os.name }}/ llvm-toolchain-${{ matrix.os.name }}${CC/#clang/} main"
+          sudo apt-get update
+          CXX=${CC/#clang/clang++}
+          sudo apt-get install $CC $CXX gcovr
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "GCOV=/usr/lib/${CC/#clang/llvm}/bin/llvm-cov gcov" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.compiler }}
+        working-directory: ${{ runner.temp }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          sudo pip3 install --upgrade pip setuptools wheel
+          pip3 install --user meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          $CC --version
+          $CXX --version
+          $GCOV --version
+          meson --version
+          ninja --version
+      - name: Configure
+        shell: bash
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+      - name: Build
+        shell: bash
+        run: ninja -C build
+      - name: Test
+        shell: bash
+        run: |
+          ninja -C build test
+      # Codecov no longer parses gcov files automatically
+      - name: Prepare coverage files
+        shell: bash
+        run: |
+          cd build
+          find . -type f -name '*.gcda' -exec $GCOV -p {} + > /dev/null
+      - name: Install
+        shell: bash
+        run: ninja -C build install
+      - name: Coverage prep
+        if: success()
+        run: gcovr -r .. -x coverage.xml --gcov-executable "$GCOV" -e ../deps -e ../test
+        working-directory: build
       - name: Codecov
-        if: success() && matrix.coverage
-        run: bash <(curl -s https://codecov.io/bash) -x "$GCOV";
+        if: success()
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os:
           - { id: ubuntu-20.04, name: focal }
+          - { id: ubuntu-22.04, name: jammy }
         compiler:
           - 'clang-9'
           - 'clang-10'
@@ -37,6 +38,14 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+        exclude:
+          # These versions are not supported by the toolchain PPA
+          - { os: { id: ubuntu-22.04 }, compiler: gcc-7 }
+          - { os: { id: ubuntu-22.04 }, compiler: gcc-8 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-9 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-10 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-11 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-12 }
       fail-fast: false
     steps:
       - name: Runtime environment
@@ -109,6 +118,7 @@ jobs:
       matrix:
         os:
           - { id: ubuntu-20.04, name: focal }
+          - { id: ubuntu-22.04, name: jammy }
         compiler:
           - 'clang-9'
           - 'clang-10'
@@ -126,6 +136,14 @@ jobs:
           - 'c++11'
           - 'c++14'
           - 'c++17'
+        exclude:
+          # These versions are not supported by the toolchain PPA
+          - { os: { id: ubuntu-22.04 }, compiler: gcc-7 }
+          - { os: { id: ubuntu-22.04 }, compiler: gcc-8 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-9 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-10 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-11 }
+          - { os: { id: ubuntu-22.04 }, compiler: clang-12 }
       fail-fast: false
     steps:
       - name: Runtime environment

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,281 @@
+name: Build macOS
+
+on:
+  push:
+    branches-ignore:
+      - 'coverityScan'
+  pull_request:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos:
+    name: '${{ matrix.os }} (${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-12
+          - macos-11
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          brew install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          cc --version  || true
+          ld --version || true
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }}
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build install
+
+  build-macos-homebrew:
+    name: '${{ matrix.os }} (${{ matrix.compiler }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os}}
+    strategy:
+      matrix:
+        os:
+          ## Apple LLD is unable to link GCC < 11 generated object files.
+          ## https://stackoverflow.com/questions/73714336/xcode-update-to-version-2395-ld-compile-problem-occurs-computedatomcount-m
+          ## rdar://FB11369327
+          # - macos-12
+          - macos-11
+        compiler:
+          ## GCC5 cannot compile anything on macOS
+          # - gcc@5
+          ## GCC6 cannot handle constexpr-ness of mmap_t
+          ## See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66297
+          # - gcc@6
+          ## GCC < 10 is known to crash on exception unwind
+          ## https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98805
+          # - gcc@7
+          # - gcc@8
+          # - gcc@9
+          - gcc@10
+          - gcc@11
+          - gcc
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Setup compiler
+        shell: bash
+        run: |
+          brew install ${{ matrix.compiler }}
+          CC=${COMPILER/@/-}
+          CXX=${CC/#gcc/g++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+        env:
+          COMPILER: ${{ matrix.compiler }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          brew install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          $CC --version
+          $CXX --version
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }}
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build install
+
+  build-coverage-macos:
+    if: github.repository == 'dragonmux/crunch'
+    name: 'coverage ${{ matrix.os }} (${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-12
+          - macos-11
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Coverage environment
+        run: |
+          echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV
+      - name: Setup tools
+        shell: bash
+        run: |
+          brew install gcovr
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          brew install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          cc --version  || true
+          ld --version || true
+          gcov --version || true
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build install
+      - name: Coverage prep
+        if: success()
+        run: gcovr -r .. -x coverage.xml -e ../deps -e ../test
+        working-directory: build
+      - name: Codecov
+        if: success()
+        uses: codecov/codecov-action@v2
+
+  build-coverage-macos-homebrew:
+    if: github.repository == 'dragonmux/crunch'
+    name: 'coverage ${{ matrix.os }} (${{ matrix.compiler }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          ## Apple LLD is unable to link GCC < 11 generated object files.
+          ## https://stackoverflow.com/questions/73714336/xcode-update-to-version-2395-ld-compile-problem-occurs-computedatomcount-m
+          ## rdar://FB11369327
+          # - macos-12
+          - macos-11
+        compiler:
+          ## GCC5 cannot compile anything on macOS
+          # - gcc@5
+          ## GCC6 cannot handle constexpr-ness of mmap_t
+          ## See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66297
+          # - gcc@6
+          ## GCC < 10 is known to crash on exception unwind
+          ## https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98805
+          # - gcc@7
+          # - gcc@8
+          # - gcc@9
+          - gcc@10
+          - gcc@11
+          - gcc
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Coverage environment
+        run: |
+          echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV
+      - name: Setup compiler
+        shell: bash
+        run: |
+          brew install ${{ matrix.compiler }} gcovr
+          CC=${COMPILER/@/-}
+          CXX=${CC/#gcc/g++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "GCOV=${CC/#gcc/gcov}" >> $GITHUB_ENV
+        env:
+          COMPILER: ${{ matrix.compiler }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          brew install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          $CC --version
+          $CXX --version
+          $GCOV --version
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build install
+      - name: Coverage prep
+        if: success()
+        run: gcovr -r .. -x coverage.xml --gcov-executable "$GCOV" -e ../deps -e ../test
+        working-directory: build
+      - name: Codecov
+        if: success()
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,75 +4,308 @@ on:
   push:
     branches-ignore:
       - 'coverityScan'
+  pull_request:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-windows:
-    runs-on: ${{matrix.os}}
+    name: '${{ matrix.os }} (msvc ${{ matrix.arch }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019]
-        arch: ['amd64', 'x86']
-        coverage: [false, true]
+        os:
+          - windows-2019
+          - windows-2022
+        arch: 
+          - x86
+          - amd64
+        cpp_std:
+          - 'c++14'
+          - 'c++17'
       fail-fast: false
     env:
       CC: cl.exe
       CXX: cl.exe
       LD: link.exe
     steps:
-      - name: Chekcout crunch
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-          submodules: true
-      - name: Runtime Environment
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Setup compiler
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
-      - name: Coverage environment
-        shell: bash
-        env:
-          COVERAGE: ${{ matrix.coverage }}
-        run: |
-          echo "Coverage enabled for build? ${{ matrix.coverage }}"
-          echo -n "COVERAGE=" >> $GITHUB_ENV
-          ([ $COVERAGE == "true" ] && echo -n 1 || echo -n 0) >> $GITHUB_ENV
-          if [ $COVERAGE == "true" ]; then
-            echo "BUILD_OPTS=--buildtype=debug" >> $GITHUB_ENV
-            curl -L1O https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/release-0.9.9.0/OpenCppCoverageSetup-x64-0.9.9.0.exe
-            MSYS2_ARG_CONV_EXCL=/dir=\;/verysilent ./OpenCppCoverageSetup-x64-0.9.9.0 \
-              /dir="C:\Program Files\OpenCppCoverage" /verysilent
-            rm OpenCppCoverageSetup-x64-0.9.9.0.exe
-          else
-            echo "BUILD_OPTS=" >> $GITHUB_ENV
-          fi
-        working-directory: ${{ runner.temp }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
       - name: Setup Meson + Ninja
         shell: bash
         run: |
-          curl -L1O https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-win.zip
-          python -m pip install --upgrade pip setuptools wheel
-          pip3 install meson
-          unzip ninja-win.zip -d /c/windows/system32
-          rm ninja-win.zip
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install meson ninja
         working-directory: ${{ runner.temp }}
       - name: Version tools
         shell: bash
         run: |
-          rm /usr/bin/link.exe
-          $CC || true
-          $LD || true
+          $CC  || true
+          $LD  || true
           meson --version
           ninja --version
       - name: Configure
-        shell: bash
-        run: meson build --prefix=$HOME/.local $BUILD_OPTS
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }}
       - name: Build
-        shell: bash
         run: ninja -C build
       - name: Test
-        shell: bash
         run: ninja -C build test
-      - name: Codecov
-        if: success() && matrix.coverage
+      - name: Install
+        run: ninja -C build install
+
+  build-windows-mingw:
+    name: '${{ matrix.os }} (${{ matrix.sys.abi }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        os:
+          - windows-2019
+        sys:
+          - { abi: mingw64, env: x86_64, compiler: gcc }
+          - { abi: ucrt64, env: ucrt-x86_64, compiler: gcc }
+          - { abi: clang64, env: clang-x86_64, compiler: clang }
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Use MinGW from MSYS
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys.abi}}
+          update: true
+          path-type: inherit
+          install: >-
+            mingw-w64-${{matrix.sys.env}}-toolchain
+      - name: Runtime environment
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Setup compiler
+        if: startsWith(matrix.sys.abi, 'mingw64') || startsWith(matrix.sys.abi, 'ucrt64')
+        run: |
+          CXX=${CC/#gcc/g++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.sys.compiler }}
+      - name: Setup compiler
+        if: startsWith(matrix.sys.abi, 'clang64')
+        run: |
+          CXX=${CC/#clang/clang++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.sys.compiler }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
         shell: bash
-        run: bash <(curl -s https://codecov.io/bash) -x "$GCOV";
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        run: |
+          $CC --version
+          $CXX --version
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }}
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build install
+
+  build-coverage-windows:
+    if: github.repository == 'dragonmux/crunch'
+    name: 'coverage ${{ matrix.os }} (msvc ${{ matrix.arch }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-2019
+          - windows-2022
+        arch: 
+          - x86
+          - amd64
+        cpp_std:
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    env:
+      CC: cl.exe
+      CXX: cl.exe
+      LD: link.exe
+    steps:
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Coverage environment
+        run: |
+          echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV
+      - name: Setup compiler
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+      - name: Setup OpenCppCoverage
+        shell: bash
+        run: |
+          curl -L1O https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/release-0.9.9.0/OpenCppCoverageSetup-x64-0.9.9.0.exe
+          MSYS2_ARG_CONV_EXCL=/dir=\;/verysilent ./OpenCppCoverageSetup-x64-0.9.9.0 \
+            /dir="C:\Program Files\OpenCppCoverage" /verysilent
+          rm OpenCppCoverageSetup-x64-0.9.9.0.exe
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        shell: bash
+        run: |
+          $CC  || true
+          $LD  || true
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      - name: Install
+        run: ninja -C build install
+      - name: Codecov
+        if: success()
+        uses: codecov/codecov-action@v2
+
+  build-coverage-windows-mingw:
+    if: github.repository == 'dragonmux/crunch'
+    name: 'coverage ${{ matrix.os }} (${{ matrix.sys.abi }}, ${{ matrix.cpp_std }})'
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        os:
+          - windows-2019
+        sys:
+          - { abi: mingw64, env: x86_64, compiler: gcc }
+          - { abi: ucrt64, env: ucrt-x86_64, compiler: gcc }
+          - { abi: clang64, env: clang-x86_64, compiler: clang }
+        cpp_std:
+          - 'c++11'
+          - 'c++14'
+          - 'c++17'
+      fail-fast: false
+    steps:
+      - name: Use MinGW from MSYS
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys.abi}}
+          update: true
+          path-type: inherit
+          install: >-
+            mingw-w64-${{matrix.sys.env}}-toolchain
+      - name: Runtime environment
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+      - name: Coverage environment
+        run: |
+          echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV
+      - name: Setup compiler
+        if: startsWith(matrix.sys.abi, 'mingw64') || startsWith(matrix.sys.abi, 'ucrt64')
+        run: |
+          CXX=${CC/#gcc/g++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "GCOV=gcov" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.sys.compiler }}
+      - name: Setup compiler
+        if: startsWith(matrix.sys.abi, 'clang64')
+        run: |
+          CXX=${CC/#clang/clang++}
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "GCOV=llvm-cov gcov" >> $GITHUB_ENV
+        env:
+          CC: ${{ matrix.sys.compiler }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          submodules: true
+      - name: Setup Meson + Ninja
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
+      - name: Version tools
+        run: |
+          $CC --version
+          $CXX --version
+          $GCOV --version
+          meson --version
+          ninja --version
+      - name: Configure
+        run: meson build --prefix=$HOME/.local -Dcpp_std=${{ matrix.cpp_std }} $BUILD_OPTS
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ninja -C build test
+      # Codecov no longer parses gcov files automatically
+      - name: Prepare coverage files
+        run: |
+          cd build
+          find . -type f -name '*.gcda' -exec $GCOV -p {} + > /dev/null
+      - name: Install
+        run: ninja -C build install
+      - name: Codecov
+        if: success()
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
       - name: Checkout crunch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
           submodules: true

--- a/test/crunch++/meson.build
+++ b/test/crunch++/meson.build
@@ -2,7 +2,7 @@ libCrunchppTestsNorm = ['testCrunch++', 'testBad', 'testRegistration', 'testLogg
 libCrunchppTestsExcept = ['testTester']
 libCrunchppTests = libCrunchppTestsNorm + libCrunchppTestsExcept
 
-if isMSVC or cxx.version().version_compare('< 19.30.30704')
+if isMSVC and cxx.version().version_compare('< 19.30.30704')
 	# MSVC 2019 crashes on testArgsParser
 	# https://developercommunity.visualstudio.com/t/Crash-on-constexpr-creation-of-a-std::ar/1547919
 	warning('Skipping testArgsParser test as it crashes MSVC')


### PR DESCRIPTION
👋 

This is the fourth part of last night's CI upgrade branch. It simply migrates the jobs to the Substrate standard, with the following additions specific to Crunch:

- Upgraded CodeQL's use of checkout to v2
- Simplified the job naming to fit on a screen/sidebar
- Running the Linux actions also on Ubuntu 22
- Excluding, on Ubuntu 22, GCC < 9 and Clang < 10 as those seem to be unsupported upstream

Please let me know if you want entries added to the Linux versions, that test the stock compilers for each OS.

I will address the deprecation warning of Codecov in a separate PR, for the time being let's make sure that we stop using their already broken Bash script. (It's been sunsetted since February 2022.)
