### PR TITLE
ci: Fix invalid runtime environment setup on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -34,12 +34,11 @@ jobs:
       LD: link.exe
     steps:
       - name: Runtime environment
-        shell: bash
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+          echo "${env:HOME}/.local/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "GITHUB_WORKSPACE=${{ env.WORKSPACE }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Setup compiler
         uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -104,7 +103,7 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+          echo "GITHUB_WORKSPACE=${{ env.WORKSPACE }}" >> $GITHUB_ENV
       - name: Setup compiler
         if: startsWith(matrix.sys.abi, 'mingw64') || startsWith(matrix.sys.abi, 'ucrt64')
         run: |
@@ -169,12 +168,11 @@ jobs:
       LD: link.exe
     steps:
       - name: Runtime environment
-        shell: bash
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+          echo "${env:HOME}/.local/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "GITHUB_WORKSPACE=${{ env.WORKSPACE }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Coverage environment
         run: |
           echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV
@@ -253,7 +251,7 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+          echo "GITHUB_WORKSPACE=${{ env.WORKSPACE }}" >> $GITHUB_ENV
       - name: Coverage environment
         run: |
           echo "BUILD_OPTS=-Db_coverage=true --buildtype=debug" >> $GITHUB_ENV


### PR DESCRIPTION
👋 

This is a PR to fix a most sneaky bug in how we set the runtime environment up... We're using Git Bash, which will escape paths the MSYS way. This will make them unusable for actions and PowerShell.

Note for Windows: The MSYS one runs inside the MSYS shell, but because it already does runtime path translation through the POSIX emulation layer, just passing the original value as supplied by GHA makes both PowerShell and MSYS happy.

To verify, check that the Windows and MinGW jobs install Crunch to the user's home folder, either the native or the MSYS filesystem one, as appropriate.