### PR TITLE
Fix issues with Windows and macOS

### DIFF
--- a/crunch++/crunch++.cpp
+++ b/crunch++/crunch++.cpp
@@ -73,6 +73,9 @@ namespace crunch
 		"dll"_sv, "so"_sv, "tlib"_sv
 	})};
 	static const std::size_t libExtMaxLength{4U};
+#elif defined(__APPLE__)
+	static const auto libExt{substrate::make_array<internal::stringView>({"so"_sv, "dylib"_sv})};
+	static const std::size_t libExtMaxLength{5U};
 #else
 	static const auto libExt{substrate::make_array<internal::stringView>({"so"_sv})};
 	static const std::size_t libExtMaxLength{2U};

--- a/crunch++/meson.build
+++ b/crunch++/meson.build
@@ -40,11 +40,11 @@ libCrunchppDep = declare_dependency(
 	link_with: libCrunchpp,
 	include_directories: crunchppInc,
 	variables: {
-		'includedir': ','.join([
-			meson.current_build_dir(),
-			meson.current_source_dir(),
+		'compile_args': ' '.join([
+			'-I@0@'.format(meson.current_build_dir()),
+			'-I@0@'.format(meson.current_source_dir()),
 		]),
-		'libdir': meson.current_build_dir(),
+		'link_args': libCrunchpp.full_path(),
 	}
 )
 

--- a/crunch/crunch.c
+++ b/crunch/crunch.c
@@ -54,6 +54,10 @@ const arg_t crunchArgs[] =
 #define COUNT_LIB_EXTS 3U
 static const char *libExt[COUNT_LIB_EXTS] = {"dll", "so", "tlib"};
 static const size_t libExtMaxLength = 4U;
+#elif defined(__APPLE__)
+#define COUNT_LIB_EXTS 2U
+static const char *libExt[COUNT_LIB_EXTS] = {"so", "dylib"};
+static const size_t libExtMaxLength = 5U;
 #else
 #define COUNT_LIB_EXTS 1U
 static const char *libExt[COUNT_LIB_EXTS] = {"so"};

--- a/crunch/meson.build
+++ b/crunch/meson.build
@@ -52,11 +52,11 @@ libCrunchDep = declare_dependency(
 	link_with: libCrunch,
 	include_directories: crunchInc,
 	variables: {
-		'includedir': ','.join([
-			meson.current_build_dir(),
-			meson.current_source_dir(),
+		'compile_args': ' '.join([
+			'-I@0@'.format(meson.current_build_dir()),
+			'-I@0@'.format(meson.current_source_dir()),
 		]),
-		'libdir': meson.current_build_dir(),
+		'link_args': libCrunch.full_path(),
 	}
 )
 

--- a/test/crunch++/meson.build
+++ b/test/crunch++/meson.build
@@ -13,41 +13,11 @@ endif
 libCrunchppPath = meson.global_build_root() / libCrunchpp.outdir()
 
 foreach test : libCrunchppTests
-	command = [crunchMake, '-s', '@INPUT@', '-o', '@OUTPUT@', '-I' + crunchppSrcDir, '-L' + libCrunchppPath]
-	if isMSVC and coverage
-		command = [coverageTarget, coverageRunner] + coverageArgs + [
-			'cobertura:crunchMake-crunch++-@0@-coverage.xml'.format(test), '--'
-		] + command
-	endif
-	testExtra = []
-	if test == 'testCrunch++' and cxx.has_argument('-std=c++17')
-		testExtra = ['-std=c++17']
-	elif test == 'testCrunch++' and cxx.has_argument('-std:c++17')
-		testExtra = ['-std:c++17']
-	elif test == 'testArgsParser' or test == 'testLogger'
-		testExtra = [substrate.get_variable('compile_args')]
-	endif
-	objects = []
-	if test == 'testLogger' and not isWindows
-		libSubstrate = substrate.get_variable('link_args')
-		if libSubstrate.endswith('/libsubstrate.so')
-			substrateDir = libSubstrate.substring(0, -16)
-		elif libSubstrate.endswith('/libsubstrate.a')
-			substrateDir = libSubstrate.substring(0, -15)
-		elif libSubstrate.endswith('/libsubstrate.dylib')
-			substrateDir = libSubstrate.substring(0, -19)
-		else
-			error('Unexpected value for substrate link_args, got \'@0@\''.format(libSubstrate))
-		endif
-		testExtra += [libSubstrate, '-Wl,-rpath,@0@'.format(substrateDir)]
-	endif
-	custom_target(
-		'crunch++-' + test,
-		command: command + commandExtra + testExtra,
-		input: [test + '.cpp', objects],
-		output: test + testExt,
-		depends: libCrunchpp,
-		build_by_default: true
+	shared_library(
+		test,
+		files(test + '.cpp'),
+		name_prefix: '',
+		dependencies: [libCrunchppDep, substrate],
 	)
 endforeach
 


### PR DESCRIPTION
👋 

This PR should take care of loading dylibs on macOS, linking against substrate's logger class on macOS (crunchMake needs further work here re: loader_path), and working around Meson interpreting `declare_dependency` variables under the hood.